### PR TITLE
Refactoring

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,32 @@
+name: Flutter
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
+          channel: 'stable'
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed lib
+
+      - name: Analyze project source
+        run: dart analyze lib
+
+      - name: Generate the mocks
+        run: flutter pub run build_runner build --delete-conflicting-outputs
+
+      - name: Run tests
+        run: flutter test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+Features:
+- Added the `RouteProvider.tag` constant to reduce magic symbols.
+
 ## 1.0.0
 
 Initial release

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,8 @@ include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -78,9 +78,8 @@ class MyApp extends StatelessWidget {
 After you set up the routing, you can register routes.
 
 ```dart
-/// Create a class that implements the RouteProvider and add the @Service annotation with a 
-/// #routeProvider tag.
-@Service(tags: [#routeProvider])
+/// Create a class that implements the RouteProvider and add the @Service annotation with a tag.
+@Service(tags: [RouteProvider.tag])
 class HomeRouteProvider implements RouteProvider {
   @override
   List<RegisteredRoute> get routes =>

--- a/doc/under-the-hood.md
+++ b/doc/under-the-hood.md
@@ -35,16 +35,16 @@ That means, we can use the given provider to resolve our `Screen/Widget n` witho
 Since the `App Routes` class is not imported anywhere (ignore generated code 😉), the coupling is not worth mentioning.
 
 As you noted, there is a connection between `DefaultServiceProvider` (DSP) and `App Routes`. That means, that the 
-`App Routes` class must be decorated with `@Service(tags: [#routeProvider])`.
+`App Routes` class must be decorated with `@Service(tags: [RouteProvider.tag])`.
 
 -----
 
 Next step: take a look on the connection between `RouteResolver` and `RouteProvider` / `ServiceProvider`.
 
 The [`RouteResolver`](../lib/src/route_resolver.dart) expects in the constructor a `List<RouteProvider>`. If you take
-a look in the code, you can see, that the constructor parameter is decorated with `@Inject(tag: #routeProvider)`.
+a look in the code, you can see, that the constructor parameter is decorated with `@Inject(tag: RouteProvider.tag)`.
 
-Now you can put two and two together. The `ServiceProvider` takes all services that are tagged with `#routeProvider`, 
+Now you can put two and two together. The `ServiceProvider` takes all services that are tagged with `RouteProvider.tag`, 
 including our `App Routes` class, and inject it as a list to the `RouteResolver`.
 
 -----

--- a/example/lib/home/routes.dart
+++ b/example/lib/home/routes.dart
@@ -2,7 +2,7 @@ import 'package:catalyst_builder/catalyst_builder.dart';
 import 'package:explorator/explorator.dart';
 import 'package:explorator_example/home/home_screen.dart';
 
-@Service(tags: [#routeProvider])
+@Service(tags: [RouteProvider.tag])
 class HomeRouteProvider implements RouteProvider {
   @override
   List<RegisteredRoute> get routes => [

--- a/example/lib/other/routes.dart
+++ b/example/lib/other/routes.dart
@@ -4,7 +4,7 @@ import 'package:explorator_example/other/variables_screen.dart';
 
 import 'other_screen.dart';
 
-@Service(tags: [#routeProvider])
+@Service(tags: [RouteProvider.tag])
 class OtherRouteProvider implements RouteProvider {
   @override
   List<RegisteredRoute> get routes => [

--- a/example/lib/splash/routes.dart
+++ b/example/lib/splash/routes.dart
@@ -2,7 +2,7 @@ import 'package:catalyst_builder/catalyst_builder.dart';
 import 'package:explorator/explorator.dart';
 import 'package:explorator_example/splash/splash_screen.dart';
 
-@Service(tags: [#routeProvider])
+@Service(tags: [RouteProvider.tag])
 class SplashRouteProvider implements RouteProvider {
   @override
   List<RegisteredRoute> get routes => [

--- a/lib/explorator.dart
+++ b/lib/explorator.dart
@@ -7,5 +7,6 @@ export 'src/registered_route.dart';
 export 'src/route_arguments.dart';
 export 'src/route_builder.dart';
 export 'src/route_expression_builder.dart';
+export 'src/route_matcher.dart';
 export 'src/route_provider.dart';
 export 'src/route_resolver.dart';

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -1,16 +1,27 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
 import 'package:explorator/explorator.dart';
-import 'package:flutter/widgets.dart';
 
+/// The RouteMatcher is used to match raw paths (/books/1234) against the
+/// registered routes.
+@Service()
 class RouteMatcher {
-  RouteMatcher(List<RouteProvider> providers);
+  final List<RegisteredRoute> _allRoutes = [];
 
-  RegisteredRoute? match(String path) {
-    if (path == '/hello') {
-      return RegisteredRoute(
-        path: 'path',
-        builder: (p) => (ctx) => Container(),
-      );
+  /// Creates a new Route Matcher.
+  /// The known routes are provided by the [routeProviders].
+  RouteMatcher(
+    @Inject(tag: RouteProvider.tag) List<RouteProvider> routeProviders,
+  ) {
+    for (var provider in routeProviders) {
+      _allRoutes.addAll(provider.routes);
     }
-    return null;
+  }
+
+  /// Returns the route that matches against the path.
+  RegisteredRoute? match(String path) {
+    return _allRoutes.cast<RegisteredRoute?>().firstWhere(
+          (route) => route!.expression.hasMatch(path),
+          orElse: () => null,
+        );
   }
 }

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -1,0 +1,16 @@
+import 'package:explorator/explorator.dart';
+import 'package:flutter/widgets.dart';
+
+class RouteMatcher {
+  RouteMatcher(List<RouteProvider> providers);
+
+  RegisteredRoute? match(String path) {
+    if (path == '/hello') {
+      return RegisteredRoute(
+        path: 'path',
+        builder: (p) => (ctx) => Container(),
+      );
+    }
+    return null;
+  }
+}

--- a/lib/src/route_provider.dart
+++ b/lib/src/route_provider.dart
@@ -2,6 +2,9 @@ import 'registered_route.dart';
 
 /// This interface describe a object that can provide routes.
 abstract class RouteProvider {
+  /// The tag for registering the route provider in catalyst_builder.
+  static const tag = #routeProvider;
+
   /// Returns the existing routes.
   List<RegisteredRoute> get routes;
 }

--- a/lib/src/route_resolver.dart
+++ b/lib/src/route_resolver.dart
@@ -7,18 +7,17 @@ import 'package:flutter/widgets.dart';
 /// by the routeProvider tag.
 @Service()
 class RouteResolver {
-  final List<RouteProvider> _providers;
   final RouteBuilder _routeBuilder;
-  final ServiceProvider _provider;
+  final ServiceProvider _serviceProvider;
   final List<RegisteredRoute> _allRoutes = [];
 
   /// RouteResolver constructor.
   RouteResolver(
-    @Inject(tag: RouteProvider.tag) this._providers,
+    @Inject(tag: RouteProvider.tag) List<RouteProvider> providers,
     this._routeBuilder,
-    this._provider,
+    this._serviceProvider,
   ) {
-    for (var provider in _providers) {
+    for (var provider in providers) {
       _allRoutes.addAll(provider.routes);
     }
   }
@@ -65,7 +64,7 @@ class RouteResolver {
     Map<String, String> queryParameters,
     RouteSettings settings,
   ) {
-    var subProvider = _provider;
+    var subProvider = _serviceProvider;
     if (subProvider is! EnhanceableProvider) {
       return subProvider;
     }

--- a/lib/src/route_resolver.dart
+++ b/lib/src/route_resolver.dart
@@ -14,7 +14,7 @@ class RouteResolver {
 
   /// RouteResolver constructor.
   RouteResolver(
-    @Inject(tag: #routeProvider) this._providers,
+    @Inject(tag: RouteProvider.tag) this._providers,
     this._routeBuilder,
     this._provider,
   ) {

--- a/lib/src/route_resolver.dart
+++ b/lib/src/route_resolver.dart
@@ -9,18 +9,14 @@ import 'package:flutter/widgets.dart';
 class RouteResolver {
   final RouteBuilder _routeBuilder;
   final ServiceProvider _serviceProvider;
-  final List<RegisteredRoute> _allRoutes = [];
+  final RouteMatcher _routeMatcher;
 
   /// RouteResolver constructor.
   RouteResolver(
-    @Inject(tag: RouteProvider.tag) List<RouteProvider> providers,
+    this._routeMatcher,
     this._routeBuilder,
     this._serviceProvider,
-  ) {
-    for (var provider in providers) {
-      _allRoutes.addAll(provider.routes);
-    }
-  }
+  );
 
   /// Resolve a route for the given [settings].
   Route<dynamic>? resolveRoute(RouteSettings settings) {
@@ -31,7 +27,7 @@ class RouteResolver {
     var uri = Uri.parse(settings.name!);
     var routeName = Uri.decodeFull(uri.path);
 
-    var route = _matchRoute(routeName);
+    var route = _routeMatcher.match(routeName);
     if (route == null) {
       return null;
     }
@@ -45,13 +41,6 @@ class RouteResolver {
 
     var widget = route.builder(subProvider);
     return _routeBuilder.build(widget, settings);
-  }
-
-  RegisteredRoute? _matchRoute(String routeName) {
-    return _allRoutes.cast<RegisteredRoute?>().firstWhere(
-          (route) => route!.expression.hasMatch(routeName),
-          orElse: () => null,
-        );
   }
 
   /// Creates a enhanced service provider which contains additional services:

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -2,12 +2,17 @@ import 'package:catalyst_builder/catalyst_builder.dart';
 import 'package:explorator/explorator.dart';
 import 'package:mockito/annotations.dart';
 
+export 'mocks.mocks.dart';
+
 dynamic resolveMock<T>() {
   return false;
 }
 
 @GenerateMocks(
-  [RouteProvider],
+  [
+    RouteProvider,
+    RouteMatcher,
+  ],
   customMocks: [
     MockSpec<ServiceProviderForTest>(fallbackGenerators: {
       #resolve: resolveMock,

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -1,0 +1,32 @@
+import 'package:explorator/explorator.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'mocks.mocks.dart';
+
+void main() {
+  group('Route Matcher', () {
+    late RouteMatcher matcher;
+
+    setUp(() {
+      var mockProvider = MockRouteProvider();
+      when(mockProvider.routes).thenReturn([
+        RegisteredRoute(path: '/hello', builder: (p0) => (ctx) => Container()),
+        RegisteredRoute(
+            path: '/hello/{name}', builder: (p0) => (ctx) => Container()),
+      ]);
+      matcher = RouteMatcher([mockProvider]);
+    });
+
+    test('No match will return null', () {
+      expect(matcher.match('/foo'), isNull);
+    });
+
+    test('On match will return the route', () {
+      var match = matcher.match('/hello');
+      expect(match, const TypeMatcher<RegisteredRoute>());
+      expect(match?.path, equals('/hello'));
+    });
+  });
+}

--- a/test/route_provider_test.dart
+++ b/test/route_provider_test.dart
@@ -1,0 +1,8 @@
+import 'package:explorator/explorator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Should have a constant with the tag', () {
+    expect(RouteProvider.tag, equals(#routeProvider));
+  });
+}

--- a/test/route_resolver_test.dart
+++ b/test/route_resolver_test.dart
@@ -23,8 +23,12 @@ void main() {
       services: anyNamed('services'),
       parameters: anyNamed('parameters'),
     )).thenAnswer((realInvocation) {
-      enhancedServices.addAll(realInvocation.namedArguments[#services]);
-      enhancedParameters.addAll(realInvocation.namedArguments[#parameters]);
+      enhancedServices.addAll(
+        realInvocation.namedArguments[#services] as List<LazyServiceDescriptor>,
+      );
+      enhancedParameters.addAll(
+        realInvocation.namedArguments[#parameters] as Map<String, dynamic>,
+      );
       return mockServiceProvider;
     });
 

--- a/test/route_resolver_test.dart
+++ b/test/route_resolver_test.dart
@@ -48,11 +48,15 @@ void main() {
 
     expect(enhancedServices, isNotEmpty);
     var first = enhancedServices.first;
+    var last = enhancedServices.last;
     var args = first.factory(mockServiceProvider) as RouteArguments;
+    var settings = last.factory(mockServiceProvider) as RouteSettings;
     expect(first.service.exposeAs, equals(RouteArguments));
     expect(first.service.lifetime, equals(ServiceLifetime.transient));
     expect(args.pathVariables, isEmpty);
     expect(args.queryParameters, isEmpty);
+
+    expect(settings, isNotNull);
   });
 
   test('resolve with arguments', () {


### PR DESCRIPTION
- RouteResolver
  - Replaced the for-_allRoutes-loop with a firstWhere call.
    - Extracted it to _matchRoute()
  - Pass the RegisteredRoute to the _createSubProvider method
  - Test coverage increased
  - Removed the _providers property since it is used only in the constructor
  - Renamed the _provider to _serviceProvider to avoid misunterstanding
  - Using the RouteMatcher
- RouteProvider
  - Added a constant for the #routeProvider symbol.
- RouteMatcher
  - Added a RouteMatcher to follow SoC principle

