### PR TITLE
feat: Added a ServiceProvider extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 Features:
 - Added the `RouteProvider.tag` constant to reduce magic symbols.
+- Added a ServiceProvider extension for registering the explorator services.
 
 ## 1.0.0
 

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -23,27 +23,16 @@ targets:
 
 ```dart
 @GenerateServiceProvider()
-// The ServiceMap is required for wiring the  RouteBuilder. Replace it with your own if necessary.
-@ServiceMap(services: {
-  MaterialRouteBuilder: Service(exposeAs: RouteBuilder),
-})
 void main() {
-  /// Create an instance of the service provider
+  // Create an instance of the service provider
   var provider = DefaultServiceProvider();
-
-  /// Register the provider itself
-  provider.register(
-        (p) => provider,
-    const Service(
-      exposeAs: ServiceProvider,
-      lifetime: ServiceLifetime.singleton,
-    ),
-  );
-
-  /// boot the provider
-  provider.boot();
-
-  /// Run the app
+  provider
+    // Extension method from the explorator package
+    ..useExplorator(
+      routeBuilder: MaterialRouteBuilder(),
+    )
+    ..boot();
+  // Run the app
   runApp(MyApp(provider));
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,29 +6,19 @@ import 'package:url_strategy/url_strategy.dart';
 import 'main.catalyst_builder.g.dart';
 
 @GenerateServiceProvider()
-// The ServiceMap is required for wiring the  RouteBuilder. Replace it with your own if necessary.
-@ServiceMap(services: {
-  MaterialRouteBuilder: Service(exposeAs: RouteBuilder),
-})
 void main() {
   setPathUrlStrategy();
 
-  /// Create an instance of the service provider
+  // Create an instance of the service provider
   var provider = DefaultServiceProvider();
+  provider
+    // Extension method from the explorator package
+    ..useExplorator(
+      routeBuilder: MaterialRouteBuilder(),
+    )
+    ..boot();
 
-  /// Register the provider itself
-  provider.register(
-    (p) => provider,
-    const Service(
-      exposeAs: ServiceProvider,
-      lifetime: ServiceLifetime.singleton,
-    ),
-  );
-
-  /// boot the provider
-  provider.boot();
-
-  /// Run the app
+  // Run the app
   runApp(MyApp(provider));
 }
 

--- a/lib/explorator.dart
+++ b/lib/explorator.dart
@@ -2,6 +2,7 @@ library explorator;
 
 export 'src/exception/unbalanced_curly_braces_exception.dart';
 export 'src/exception/unexpected_char_exception.dart';
+export 'src/extensions.dart';
 export 'src/material_route_builder.dart';
 export 'src/registered_route.dart';
 export 'src/route_arguments.dart';

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,39 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
+import 'package:explorator/explorator.dart';
+
+/// This extension simplifies the configuration for the explorator package.
+extension ServiceProviderExtension on ServiceProvider {
+  /// Register necessary services for using the explorator package.
+  void useExplorator({
+    RouteBuilder? routeBuilder,
+  }) {
+    if (this is! ServiceRegistry) return;
+
+    _addServiceProvider();
+    _addRouteBuilder(routeBuilder);
+  }
+
+  void _addServiceProvider() {
+    if (has<dynamic>(ServiceProvider)) return;
+
+    (this as ServiceRegistry).register<ServiceProvider>(
+      (p) => this,
+      const Service(
+        exposeAs: ServiceProvider,
+        lifetime: ServiceLifetime.singleton,
+      ),
+    );
+  }
+
+  void _addRouteBuilder(RouteBuilder? routeBuilder) {
+    if (routeBuilder == null || has<dynamic>(RouteBuilder)) return;
+
+    (this as ServiceRegistry).register<RouteBuilder>(
+      (p) => routeBuilder,
+      const Service(
+        exposeAs: RouteBuilder,
+        lifetime: ServiceLifetime.singleton,
+      ),
+    );
+  }
+}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -4,9 +4,7 @@ import 'package:mockito/annotations.dart';
 
 export 'mocks.mocks.dart';
 
-dynamic resolveMock<T>() {
-  return false;
-}
+dynamic resolveMock<T>() => false;
 
 @GenerateMocks(
   [
@@ -21,7 +19,8 @@ dynamic resolveMock<T>() {
 )
 void main() {}
 
-class ServiceProviderForTest implements ServiceProvider, EnhanceableProvider {
+class ServiceProviderForTest
+    implements ServiceProvider, EnhanceableProvider, ServiceRegistry {
   @override
   void boot() {}
 
@@ -45,4 +44,12 @@ class ServiceProviderForTest implements ServiceProvider, EnhanceableProvider {
 
   @override
   List resolveByTag(Symbol tag) => throw UnimplementedError();
+
+  @override
+  void register<T>(
+    ServiceFactory<T> factory, [
+    Service service = const Service(),
+  ]) {
+    throw UnimplementedError();
+  }
 }

--- a/test/provider_extension_test.dart
+++ b/test/provider_extension_test.dart
@@ -1,0 +1,50 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
+import 'package:explorator/explorator.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+
+void main() {
+  group('Service Provider Extension', () {
+    late MockServiceProviderForTest mockServiceProvider;
+
+    setUp(() {
+      mockServiceProvider = MockServiceProviderForTest();
+    });
+
+    test('useExplorator register the service provider itself', () {
+      when(mockServiceProvider.has<dynamic>(ServiceProvider)).thenReturn(false);
+
+      mockServiceProvider.useExplorator();
+      verify(mockServiceProvider.has<dynamic>(ServiceProvider));
+
+      var captured = verify(mockServiceProvider.register<ServiceProvider>(
+          captureAny, captureAny));
+      expect(
+        captured.captured[0](mockServiceProvider),
+        same(mockServiceProvider),
+      );
+      expect(captured.captured[1], const TypeMatcher<Service>());
+    });
+
+    test('useExplorator register route builder', () {
+      when(mockServiceProvider.has<dynamic>(ServiceProvider)).thenReturn(true);
+      when(mockServiceProvider.has<dynamic>(RouteBuilder)).thenReturn(false);
+
+      var routeBuilder = MaterialRouteBuilder();
+      mockServiceProvider.useExplorator(routeBuilder: routeBuilder);
+      verify(mockServiceProvider.has<dynamic>(RouteBuilder));
+
+      var captured = verify(
+        mockServiceProvider.register<RouteBuilder>(captureAny, captureAny),
+      );
+
+      expect(
+        captured.captured[0](mockServiceProvider),
+        const TypeMatcher<RouteBuilder>(),
+      );
+      expect(captured.captured[1], const TypeMatcher<Service>());
+    });
+  });
+}


### PR DESCRIPTION
Added a ServiceProvider extension for registering the explorator services. This simplifies the usage of the package.

Usage:
```diff
- // The ServiceMap is required for wiring the  RouteBuilder. Replace it with your own if necessary.
- @ServiceMap(services: {
-   MaterialRouteBuilder: Service(exposeAs: RouteBuilder),
- })
@GenerateServiceProvider()
 void main() {
  // Create an instance of the service provider
  var provider = DefaultServiceProvider();
-  /// Register the provider itself
-  provider.register(
-        (p) => provider,
-    const Service(
-      exposeAs: ServiceProvider,
-      lifetime: ServiceLifetime.singleton,
-    ),
-  );

  provider
+    // Extension method from the explorator package
+    ..useExplorator(
+      routeBuilder: MaterialRouteBuilder(),
+    )
    ..boot();
  // Run the app
  runApp(MyApp(provider));
}
```